### PR TITLE
Updated to match current version of katcp

### DIFF
--- a/src/katcp_wrapper.py
+++ b/src/katcp_wrapper.py
@@ -83,7 +83,8 @@ class FpgaClient(CallbackClient):
         super(FpgaClient, self).__init__(host, port, tb_limit = tb_limit, timeout = timeout, logger = logger)
         self.host = host
         self._timeout = timeout
-        self.start(daemon = True)
+        self.setDaemon(True)
+        self.start()
 
         # async stuff
         self._nb_request_id_lock = threading.Lock()


### PR DESCRIPTION
katcp.CallbackClient.start() doesn't have a `daemon` argument. At least not in the current version of katcp.
